### PR TITLE
Fixed mask removal

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -22,8 +22,9 @@ end)
 function Utils.GetMugShot()
 	if promiseId then return end
 
-	local ped = cache.ped
+		local ped = cache.ped
     local oldMask = GetPedDrawableVariation(ped, 1)
+		local numberoftexture = GetPedTextureVariation(ped,1)
     local hasMask = oldMask ~= 0
 
     if hasMask then
@@ -39,12 +40,11 @@ function Utils.GetMugShot()
 	Utils.SendNUIEvent(events.Send.requestBaseUrl, headShotTxd)
 	UnregisterPedheadshot(headShotHandle)
 	if hasMask then
-        SetPedComponentVariation(ped, 1, oldMask, 0, 2)
+        SetPedComponentVariation(ped, 1, oldMask, numberoftexture, 2)
     end
 
 	promiseId = promise.new()
     return Citizen.Await(promiseId)
-end
 
 function Utils.GetPlayerLookingAt()
     local config = require "shared.config"


### PR DESCRIPTION
When the mask gets removed to take the picture it puts it back with the variation 0, also i use qb-core and the items were retuning nil metadata. so i redid the createlicense but i didnt push it knowing that this will not be mainly for Qb.